### PR TITLE
Fix Advancement messages, better logic for /top-deaths

### DIFF
--- a/src/main/java/fm/truckers/truckersfmPlugin/commands/TopDeathsCommand.java
+++ b/src/main/java/fm/truckers/truckersfmPlugin/commands/TopDeathsCommand.java
@@ -26,13 +26,22 @@ public class TopDeathsCommand extends AbstractCommand {
     protected void handleCommand(Player player, CommandArguments args) {
         // Fetch all online players and sort them by deaths
         List<Player> topPlayers = Bukkit.getOnlinePlayers().stream()
-                .filter(onlinePlayer -> onlinePlayer.getStatistic(Statistic.PLAY_ONE_MINUTE) > 0) // Only include players with at least 1 death
+                .filter(onlinePlayer -> onlinePlayer.getStatistic(Statistic.DEATHS) > 0) // Only include players with at least 1 death
                 .sorted(Comparator.comparingInt((Player p) -> p.getStatistic(Statistic.DEATHS)).reversed())
                 .limit(10)
                 .collect(Collectors.toList());
 
+        if (topPlayers.isEmpty()) {
+            // this should be pretty rare
+            Component noDeathsMsg = Component.text("Wow, nobody who is online right now has ever died before!", NamedTextColor.GOLD)
+                    .append(Component.newline())
+                    .append(Component.text("Incredible Job!", NamedTextColor.GREEN));
+            player.sendMessage(noDeathsMsg);
+            return;
+        }
+
         // Build the leaderboard message
-        Component leaderboard = Component.text("Top 10 players by deaths", NamedTextColor.GOLD).append(Component.newline());
+        Component leaderboard = Component.text("Top 10 online players by deaths", NamedTextColor.GOLD).append(Component.newline());
         int rank = 1;
         for (Player topPlayer : topPlayers) {
             leaderboard = leaderboard.append(

--- a/src/main/java/fm/truckers/truckersfmPlugin/listeners/PlayerEventListener.java
+++ b/src/main/java/fm/truckers/truckersfmPlugin/listeners/PlayerEventListener.java
@@ -47,9 +47,13 @@ public class PlayerEventListener implements Listener {
 
     @EventHandler
     public void onPlayerAdvancementDone(PlayerAdvancementDoneEvent event) {
-        if (hiddenPlayers.contains(event.getPlayer().getUniqueId().toString())) {
-            event.message(null); // Hide the message
+        // If the player isn't hidden, do nothing
+        // this means the advancement notification will proceed as usual
+        if (!hiddenPlayers.contains(event.getPlayer().getUniqueId().toString())) {
+            return;
         }
+
+        event.message(null); // Hide the message
 
         // Get the advancement name (display title)
         Advancement advancement = event.getAdvancement();


### PR DESCRIPTION
Fixes #1.

Also improves some (in my opinion) wrong logic and makes the messages a bit clearer for the `/top-deaths` command.

Changes have been tested on a local test server as provided by the `runServer` gradle task.